### PR TITLE
fix: bump `rxjs` peer dep to 7.5

### DIFF
--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -30,6 +30,6 @@
     "README.md"
   ],
   "peerDependencies": {
-    "rxjs": "~6.6.7"
+    "rxjs": "~7.5.0"
   }
 }

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -30,6 +30,6 @@
     "README.md"
   ],
   "peerDependencies": {
-    "rxjs": "~6.6.7"
+    "rxjs": "~7.5.0"
   }
 }


### PR DESCRIPTION
Fixes missing bump of `rxjs` peer deps to 7.5