### PR TITLE
feat(rxjs-node-fs): add `rename`

### DIFF
--- a/packages/fs/README.md
+++ b/packages/fs/README.md
@@ -29,6 +29,7 @@ npm i @ckapp/rxjs-node-fs
 - `appendFile`
 - `readDir`
 - `readFile`
+- `rename`
 - `stat`
 - `watch`
 - `writeFile`

--- a/packages/fs/src/append-file.ts
+++ b/packages/fs/src/append-file.ts
@@ -1,6 +1,6 @@
 import { PathLike, promises, WriteFileOptions } from 'fs';
 import { defer, Observable } from 'rxjs';
-import { mapTo } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 
 export type AppendFileOptions = WriteFileOptions;
 
@@ -91,6 +91,6 @@ export function appendFile(
   options?: AppendFileOptions | null,
 ): Observable<AppendFileResult> {
   return defer(() => promises.appendFile(path, data, options)).pipe(
-    mapTo({ path, data }),
+    map(() => ({ path, data })),
   );
 }

--- a/packages/fs/src/index.ts
+++ b/packages/fs/src/index.ts
@@ -1,6 +1,7 @@
 export * from './append-file';
 export * from './read-dir';
 export * from './read-file';
+export * from './rename';
 export * from './stat';
 export * from './watch';
 export * from './write-file';

--- a/packages/fs/src/rename.spec.ts
+++ b/packages/fs/src/rename.spec.ts
@@ -1,0 +1,17 @@
+import { rename as _rename } from 'fs';
+import { bindNodeCallback } from 'rxjs';
+import { rename } from './rename';
+
+jest.mock('rxjs', () => {
+  return { bindNodeCallback: jest.fn(v => v) };
+});
+
+describe('rename', () => {
+  it('should be defined', () => {
+    expect(rename).toBeDefined();
+  });
+
+  it('should bind node callback', () => {
+    expect(bindNodeCallback).toBeCalledWith(_rename);
+  });
+});

--- a/packages/fs/src/rename.ts
+++ b/packages/fs/src/rename.ts
@@ -1,0 +1,15 @@
+import { rename as _rename } from 'fs';
+import { bindNodeCallback } from 'rxjs';
+
+/**
+ * Asynchronously rename file at `oldPath` to the pathname provided as `newPath`.
+ * In the case that `newPath` already exists, it will be overwritten.
+ * If there is a directory at `newPath`, an error will be raised instead.
+ *
+ * @param oldPath Old path that should be renamed
+ * @param newPath Name of the path to rename `oldPath` to
+ *
+ * @returns
+ * An observable that emits when the path was renamed, then completes.
+ */
+export const rename = bindNodeCallback(_rename);

--- a/packages/fs/src/write-file.ts
+++ b/packages/fs/src/write-file.ts
@@ -1,6 +1,6 @@
 import { PathLike, promises, WriteFileOptions } from 'fs';
 import { defer, Observable } from 'rxjs';
-import { mapTo } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 
 export { WriteFileOptions };
 
@@ -91,6 +91,6 @@ export function writeFile(
   options?: WriteFileOptions | null,
 ): Observable<WriteFileResult> {
   return defer(() => promises.writeFile(path, data, options)).pipe(
-    mapTo({ path, data }),
+    map(() => ({ path, data })),
   );
 }


### PR DESCRIPTION
Wraps `rename` using `bindNodeCallback`